### PR TITLE
Validator ranked by staked amount

### DIFF
--- a/src/api/validator.ts
+++ b/src/api/validator.ts
@@ -8,6 +8,7 @@ export type ValidatorResponse = {
     address: string;
     name: string;
     commission: number;
+    stakedAmount: string; // Added the stakedAmount field
   }[];
 };
 
@@ -43,5 +44,6 @@ export const getValidators = async (
     console.error("validators - backend error:", response.statusText);
   }
 
-  return response.json();
+  const data = await response.json();
+  return data as ValidatorResponse; // Ensure the response is correctly typed
 };

--- a/src/api/validator.ts
+++ b/src/api/validator.ts
@@ -7,7 +7,7 @@ export type ValidatorResponse = {
   validators: {
     address: string;
     name: string;
-    commission: number;
+    commission: string;
     stakedAmount: string;
   }[];
 };

--- a/src/api/validator.ts
+++ b/src/api/validator.ts
@@ -8,7 +8,7 @@ export type ValidatorResponse = {
     address: string;
     name: string;
     commission: number;
-    stakedAmount: string; // Added the stakedAmount field
+    stakedAmount: string;
   }[];
 };
 
@@ -44,6 +44,5 @@ export const getValidators = async (
     console.error("validators - backend error:", response.statusText);
   }
 
-  const data = await response.json();
-  return data as ValidatorResponse; // Ensure the response is correctly typed
+  return response.json();
 };

--- a/src/app/stake/Transaction.tsx
+++ b/src/app/stake/Transaction.tsx
@@ -142,7 +142,7 @@ export function Transaction({
 
   return (
     <>
-      <h1 className="font-bold text-xl text-center">Transfer</h1>
+      <h1 className="font-bold text-xl text-center">Stake</h1>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8 px-4">
           <FormField

--- a/src/app/stake/helpers.ts
+++ b/src/app/stake/helpers.ts
@@ -203,7 +203,7 @@ export const createValidatorList = (
   chainsDetails: (GetChainDetailsResponse | undefined | null)[],
   mobulaMarketData: MobulaMarketMultiDataResponse | undefined | null
 ): Validator[] => {
-  let validators = validatorData.reduce<Validator[]>((acc, current) => {
+  return validatorData.reduce<Validator[]>((acc, current) => {
     const chainDetails = chainsDetails.find(
       (chainDetails) => chainDetails?.id === current?.chainId
     );
@@ -236,11 +236,4 @@ export const createValidatorList = (
 
     return [...acc, ...chainValidators];
   }, []);
-
-  // Sort validators by staked amount in descending order
-  validators = validators.sort(
-    (a, b) => (b.stakedAmount || 0) - (a.stakedAmount || 0)
-  );
-
-  return validators;
 };

--- a/src/app/stake/helpers.ts
+++ b/src/app/stake/helpers.ts
@@ -203,14 +203,16 @@ export const createValidatorList = (
   chainsDetails: (GetChainDetailsResponse | undefined | null)[],
   mobulaMarketData: MobulaMarketMultiDataResponse | undefined | null
 ): Validator[] => {
-  return validatorData.reduce<Validator[]>((acc, current) => {
+  let validators = validatorData.reduce<Validator[]>((acc, current) => {
     const chainDetails = chainsDetails.find(
       (chainDetails) => chainDetails?.id === current?.chainId
     );
     if (!chainDetails) return acc;
 
-    const validators = current?.validators.reduce<Validator[]>(
+    const chainValidators = current?.validators.reduce<Validator[]>(
       (subAcc, validator) => {
+        const stakedAmount = validator.stakedAmount || "0";
+
         return [
           ...subAcc,
           {
@@ -223,14 +225,22 @@ export const createValidatorList = (
             }),
             decimals: chainDetails.decimals,
             ticker: chainDetails.ticker,
+            stakedAmount: parseFloat(stakedAmount),
           },
         ];
       },
       []
     );
 
-    if (!validators) return acc;
+    if (!chainValidators) return acc;
 
-    return [...acc, ...validators];
+    return [...acc, ...chainValidators];
   }, []);
+
+  // Sort validators by staked amount in descending order
+  validators = validators.sort(
+    (a, b) => (b.stakedAmount || 0) - (a.stakedAmount || 0)
+  );
+
+  return validators;
 };

--- a/src/app/stake/helpers.ts
+++ b/src/app/stake/helpers.ts
@@ -203,37 +203,39 @@ export const createValidatorList = (
   chainsDetails: (GetChainDetailsResponse | undefined | null)[],
   mobulaMarketData: MobulaMarketMultiDataResponse | undefined | null
 ): Validator[] => {
-  return validatorData.reduce<Validator[]>((acc, current) => {
-    const chainDetails = chainsDetails.find(
-      (chainDetails) => chainDetails?.id === current?.chainId
-    );
-    if (!chainDetails) return acc;
+  return validatorData
+    .reduce<Validator[]>((acc, current) => {
+      const chainDetails = chainsDetails.find(
+        (chainDetails) => chainDetails?.id === current?.chainId
+      );
+      if (!chainDetails) return acc;
 
-    const chainValidators = current?.validators.reduce<Validator[]>(
-      (subAcc, validator) => {
-        const stakedAmount = validator.stakedAmount || "0";
+      const chainValidators = current?.validators.reduce<Validator[]>(
+        (subAcc, validator) => {
+          const stakedAmount = validator.stakedAmount || "0";
 
-        return [
-          ...subAcc,
-          {
-            ...validator,
-            chainId: current.chainId,
-            chainName: chainDetails.name,
-            chainLogo: resolveLogo({
-              asset: { name: chainDetails.name, ticker: chainDetails.ticker },
-              mobulaMarketData,
-            }),
-            decimals: chainDetails.decimals,
-            ticker: chainDetails.ticker,
-            stakedAmount: parseFloat(stakedAmount),
-          },
-        ];
-      },
-      []
-    );
+          return [
+            ...subAcc,
+            {
+              ...validator,
+              chainId: current.chainId,
+              chainName: chainDetails.name,
+              chainLogo: resolveLogo({
+                asset: { name: chainDetails.name, ticker: chainDetails.ticker },
+                mobulaMarketData,
+              }),
+              decimals: chainDetails.decimals,
+              ticker: chainDetails.ticker,
+              stakedAmount: parseFloat(stakedAmount),
+            },
+          ];
+        },
+        []
+      );
 
-    if (!chainValidators) return acc;
+      if (!chainValidators) return acc;
 
-    return [...acc, ...chainValidators];
-  }, []);
+      return [...acc, ...chainValidators];
+    }, [])
+    .sort((a, b) => b.stakedAmount - a.stakedAmount);
 };

--- a/src/app/stake/helpers.ts
+++ b/src/app/stake/helpers.ts
@@ -154,7 +154,7 @@ export const getAddressStakingPositions = (
             ...position,
             addresses: [accountData.address].concat(currentAddresses),
             validatorName: validatorInfo?.name,
-            commission: validatorInfo?.commission,
+            commission: Number(validatorInfo?.commission),
             chainId: accountData.chainId,
             chainLogo: resolveLogo({
               asset: { name: chainDetails.name, ticker: chainDetails.ticker },
@@ -218,6 +218,7 @@ export const createValidatorList = (
             ...subAcc,
             {
               ...validator,
+              commission: Number(validator.commission),
               chainId: current.chainId,
               chainName: chainDetails.name,
               chainLogo: resolveLogo({
@@ -226,7 +227,7 @@ export const createValidatorList = (
               }),
               decimals: chainDetails.decimals,
               ticker: chainDetails.ticker,
-              stakedAmount: parseFloat(stakedAmount),
+              stakedAmount: Number(stakedAmount),
             },
           ];
         },

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -62,6 +62,7 @@ export type Chain = {
 };
 
 export type Validator = {
+  stakedAmount: number;
   address: string;
   name: string;
   commission: number;


### PR DESCRIPTION
Now validators are ranked by stakedAmount

<img width="758" alt="Capture d’écran 2024-07-17 à 17 35 49" src="https://github.com/user-attachments/assets/a945f308-6994-4c43-8f3e-3730466d6307">

Making it easier to test and validate the staking flow, but also more user friendly

(Note for later: maybe displaying the stakedAmount somewhere could be relevant)