### PR TITLE
Update Asset BreakDown

### DIFF
--- a/src/app/portfolio/AssetsBreakdown.tsx
+++ b/src/app/portfolio/AssetsBreakdown.tsx
@@ -72,7 +72,7 @@ const AssetsBreakdownRow: React.FC<{
 export const AssetsBreakdown: React.FC<{
   isLoading: boolean;
   assets: Asset[];
-  stakingPositions?: StakingPosition[]; // Optional to handle undefined case
+  stakingPositions?: StakingPosition[];
   totalBalance: number;
   hideLowBalance: boolean;
   setHideLowBalance: (value: boolean) => void;
@@ -81,7 +81,7 @@ export const AssetsBreakdown: React.FC<{
   assets,
   totalBalance,
   hideLowBalance,
-  stakingPositions = [], // Default to an empty array
+  stakingPositions = [],
   setHideLowBalance,
 }) => {
   const filteredAggregatedAssets = useMemo(() => {
@@ -128,20 +128,6 @@ export const AssetsBreakdown: React.FC<{
     return filterAndSortAssets(aggregatedAssets, hideLowBalance);
   }, [assets, hideLowBalance, stakingPositions]);
 
-  // Calculate the total balance including staking positions
-  const totalBalanceIncludingStaking = useMemo(() => {
-    const assetsBalance = assets.reduce(
-      (total, asset) => total + (asset.balanceUSD || 0),
-      0
-    );
-    const stakingBalance = stakingPositions.reduce(
-      (total, position) =>
-        total + (position.amountUSD || 0) + (position.rewardAmountUSD || 0),
-      0
-    );
-    return assetsBalance + stakingBalance;
-  }, [assets, stakingPositions]);
-
   return (
     <div className="order-first md:order-last">
       <Card className="lg:col-span-2">
@@ -163,7 +149,7 @@ export const AssetsBreakdown: React.FC<{
                     <AssetsBreakdownRow
                       key={`${i}_${asset.name}`}
                       asset={asset}
-                      totalBalance={totalBalanceIncludingStaking} // Use the updated total balance
+                      totalBalance={totalBalance}
                     />
                   );
                 })}

--- a/src/app/portfolio/AssetsBreakdown.tsx
+++ b/src/app/portfolio/AssetsBreakdown.tsx
@@ -12,6 +12,7 @@ import {
 import { formatAmountUSD } from "~/utils/helper";
 import { Asset } from "~/utils/types";
 import { filterAndSortAssets } from "./helpers";
+import { StakingPosition } from "../stake/helpers";
 
 const AssetsBreakdownRow: React.FC<{
   asset: Asset;
@@ -71,6 +72,7 @@ const AssetsBreakdownRow: React.FC<{
 export const AssetsBreakdown: React.FC<{
   isLoading: boolean;
   assets: Asset[];
+  stakingPositions?: StakingPosition[]; // Optional to handle undefined case
   totalBalance: number;
   hideLowBalance: boolean;
   setHideLowBalance: (value: boolean) => void;
@@ -79,10 +81,10 @@ export const AssetsBreakdown: React.FC<{
   assets,
   totalBalance,
   hideLowBalance,
+  stakingPositions = [], // Default to an empty array
   setHideLowBalance,
 }) => {
   const filteredAggregatedAssets = useMemo(() => {
-    // Group assets by chainId
     // FIXME Replace with Object.groupBy() when Node.js 21 becomes supported by Vercel
     const assetsPerChain = _.groupBy(
       assets,
@@ -98,10 +100,20 @@ export const AssetsBreakdown: React.FC<{
           const chain = assetsPerChain[chainId].find((asset) => !asset.assetId);
           if (chain) {
             // Aggregate the USD balance of the main asset + all tokens
-            const totalBalanceUSD = assetsPerChain[chainId].reduce(
+            let totalBalanceUSD = assetsPerChain[chainId].reduce(
               (balance, asset) => balance + (asset.balanceUSD || 0),
               0
             );
+
+            // Add staking positions' amountUSD and rewardAmountUSD to the total balance
+            const stakingPosition = stakingPositions.find(
+              (position) => position.chainId === chainId
+            );
+            if (stakingPosition) {
+              totalBalanceUSD +=
+                (stakingPosition.amountUSD || 0) +
+                (stakingPosition.rewardAmountUSD || 0);
+            }
 
             return {
               ...chain,
@@ -113,7 +125,21 @@ export const AssetsBreakdown: React.FC<{
     ).sort();
 
     return filterAndSortAssets(aggregatedAssets, hideLowBalance);
-  }, [assets, hideLowBalance]);
+  }, [assets, hideLowBalance, stakingPositions]);
+
+  // Calculate the total balance including staking positions
+  const totalBalanceIncludingStaking = useMemo(() => {
+    const assetsBalance = assets.reduce(
+      (total, asset) => total + (asset.balanceUSD || 0),
+      0
+    );
+    const stakingBalance = stakingPositions.reduce(
+      (total, position) =>
+        total + (position.amountUSD || 0) + (position.rewardAmountUSD || 0),
+      0
+    );
+    return assetsBalance + stakingBalance;
+  }, [assets, stakingPositions]);
 
   return (
     <div className="order-first md:order-last">
@@ -131,7 +157,7 @@ export const AssetsBreakdown: React.FC<{
                     <AssetsBreakdownRow
                       key={`${i}_${asset.name}`}
                       asset={asset}
-                      totalBalance={totalBalance}
+                      totalBalance={totalBalanceIncludingStaking} // Use the updated total balance
                     />
                   );
                 })}

--- a/src/app/portfolio/AssetsList.tsx
+++ b/src/app/portfolio/AssetsList.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from "lucide-react";
+import { Loader2, Info } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Checkbox } from "~/components/ui/checkbox";
@@ -92,7 +92,12 @@ export const AssetsList: React.FC<{
     <>
       <Card className="lg:col-span-2">
         <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>Assets</CardTitle>
+          <div className="flex items-center">
+            <CardTitle>Assets</CardTitle>
+            <Tooltip text="List of your available assets and their balances">
+              <Info className="w-4 h-4 ml-2 text-gray-500 cursor-pointer" />
+            </Tooltip>
+          </div>
           <Button
             type="submit"
             onClick={() => setOpenTransaction(!openTransaction)}

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -18,7 +18,7 @@ import { showroomAddresses } from "../../utils/showroomAddresses";
 import {
   aggregateStakingBalances,
   getAddressStakingPositions,
-} from "../stake/helpers"; // Added getAddressStakingPositions
+} from "../stake/helpers";
 import { WalletSelection } from "../wallets/WalletSelection";
 import { WalletSigner } from "../wallets/WalletSigner";
 import { AssetsBalances } from "./AssetsBalances";
@@ -103,7 +103,7 @@ export default function Portfolio() {
           addressesData,
           chainsDetails || [],
           mobulaMarketData,
-          [] // Pass the correct validator data if needed
+          []
         )
       ),
     [addressesData, chainsDetails, mobulaMarketData]
@@ -199,7 +199,7 @@ export default function Portfolio() {
           totalBalance={totalBalance}
           hideLowBalance={hideLowBalance}
           setHideLowBalance={setHideLowBalance}
-          stakingPositions={stakingPositions} // Pass staking positions here
+          stakingPositions={stakingPositions}
         />
       </div>
 

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -15,7 +15,10 @@ import { useMobulaMarketMultiData } from "~/hooks/useMobulaMarketMultiData";
 import { useWallet } from "~/hooks/useWallet";
 import { useChains } from "~/hooks/useChains";
 import { showroomAddresses } from "../../utils/showroomAddresses";
-import { aggregateStakingBalances } from "../stake/helpers";
+import {
+  aggregateStakingBalances,
+  getAddressStakingPositions,
+} from "../stake/helpers"; // Added getAddressStakingPositions
 import { WalletSelection } from "../wallets/WalletSelection";
 import { WalletSigner } from "../wallets/WalletSigner";
 import { AssetsBalances } from "./AssetsBalances";
@@ -90,6 +93,18 @@ export default function Portfolio() {
         mobulaMarketData
       ),
     [chainsDetails, addressesData, mobulaMarketData]
+  );
+
+  // Fetch staking positions
+  const stakingPositions = useMemo(
+    () =>
+      getAddressStakingPositions(
+        addressesData,
+        chainsDetails || [],
+        mobulaMarketData,
+        [] // Pass the correct validator data if needed
+      ),
+    [addressesData, chainsDetails, mobulaMarketData]
   );
 
   const isLoading =
@@ -182,6 +197,7 @@ export default function Portfolio() {
           totalBalance={totalBalance}
           hideLowBalance={hideLowBalance}
           setHideLowBalance={setHideLowBalance}
+          stakingPositions={Object.values(stakingPositions)} // Pass staking positions here
         />
       </div>
 

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -98,11 +98,13 @@ export default function Portfolio() {
   // Fetch staking positions
   const stakingPositions = useMemo(
     () =>
-      getAddressStakingPositions(
-        addressesData,
-        chainsDetails || [],
-        mobulaMarketData,
-        [] // Pass the correct validator data if needed
+      Object.values(
+        getAddressStakingPositions(
+          addressesData,
+          chainsDetails || [],
+          mobulaMarketData,
+          [] // Pass the correct validator data if needed
+        )
       ),
     [addressesData, chainsDetails, mobulaMarketData]
   );
@@ -197,7 +199,7 @@ export default function Portfolio() {
           totalBalance={totalBalance}
           hideLowBalance={hideLowBalance}
           setHideLowBalance={setHideLowBalance}
-          stakingPositions={Object.values(stakingPositions)} // Pass staking positions here
+          stakingPositions={stakingPositions} // Pass staking positions here
         />
       </div>
 


### PR DESCRIPTION
Staking Positions are now passed to Asset Breakdowns in order to properly calculate the total balance on each chain, and therefore the proper distribution of assets across networks in %

Before
<img width="1101" alt="Capture d’écran 2024-07-25 à 22 36 09" src="https://github.com/user-attachments/assets/31dd9c0c-3fad-4a73-8ae3-a9ecb0451215">

After
<img width="1103" alt="Capture d’écran 2024-07-25 à 22 36 37" src="https://github.com/user-attachments/assets/d3508662-1053-41ec-b4a7-10e1c8eb4ef4">


Also added some new tooltips
<img width="321" alt="Capture d’écran 2024-07-25 à 22 36 58" src="https://github.com/user-attachments/assets/cc30352c-31a7-43a3-b675-b9bc9b5d5f42">
<img width="629" alt="Capture d’écran 2024-07-25 à 22 37 13" src="https://github.com/user-attachments/assets/448249eb-a70a-40e0-8f46-d9156de0dc07">
