### PR TITLE
Adv 299 hide low balance isn t working properly for tokens

### DIFF
--- a/src/app/portfolio/AssetsBreakdown.tsx
+++ b/src/app/portfolio/AssetsBreakdown.tsx
@@ -166,7 +166,7 @@ export const AssetsBreakdown: React.FC<{
                     htmlFor="hideBalanceAssetsBreakdown"
                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                   >
-                    {`Hide low balances (< 1$)`}
+                    {`Hide chains with low balances (< 1$)`}
                   </label>
                 </div>
               </div>

--- a/src/app/portfolio/AssetsList.tsx
+++ b/src/app/portfolio/AssetsList.tsx
@@ -138,27 +138,6 @@ export const AssetsList: React.FC<{
                       </TableCell>
                     </TableRow>
                   )}
-                  <TableRow>
-                    <TableCell colSpan={5}>
-                      <div className="items-top flex space-x-2">
-                        <Checkbox
-                          id="hideBalanceAssetsList"
-                          checked={hideLowBalance}
-                          onClick={() => {
-                            setHideLowBalance(!hideLowBalance);
-                          }}
-                        />
-                        <div className="grid gap-1.5 leading-none">
-                          <label
-                            htmlFor="hideBalanceAssetsList"
-                            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                          >
-                            {`Hide low balances (< 1$)`}
-                          </label>
-                        </div>
-                      </div>
-                    </TableCell>
-                  </TableRow>
                 </TableBody>
               </Table>
             </>

--- a/src/app/portfolio/helpers.ts
+++ b/src/app/portfolio/helpers.ts
@@ -180,13 +180,23 @@ export const filterAndSortAssets = (
   assets: Asset[],
   hideLowBalance: boolean
 ) => {
+  // Aggregate the balance for each chainId
+  const aggregatedBalances: Record<string, number> = {};
+
+  assets.forEach((asset) => {
+    if (!aggregatedBalances[asset.chainId]) {
+      aggregatedBalances[asset.chainId] = 0;
+    }
+    aggregatedBalances[asset.chainId] += asset.balanceUSD || 0;
+  });
+
   return (
     assets
       // Remove empty items
       .filter(Boolean)
       // Apply low balances filter if necessary
       .filter((asset) => {
-        return !(hideLowBalance && (asset?.balanceUSD || 0) <= 1);
+        return !(hideLowBalance && aggregatedBalances[asset.chainId] <= 1);
       })
       // Hide all asset without logo (mostly spam coins for EVM)
       .filter((asset) => {

--- a/src/app/portfolio/helpers.ts
+++ b/src/app/portfolio/helpers.ts
@@ -202,11 +202,6 @@ export const filterAndSortAssets = (
       .filter((asset) => {
         return asset?.logo !== "";
       })
-      // Remove 0.0000 balances
-      // formatAmount return (0) in case of truncase 0.00000
-      .filter((asset) => {
-        return formatAmount(asset?.balanceMainUnit, 5) !== "0";
-      })
 
       .sort((a, b) => {
         // Highest to lowest USD balance


### PR DESCRIPTION
Fixed the filtering to include token balances in the calculation
Removed the filtering on 0 asset balance (to allow to see chains where native asset balance = 0 but token value is > 0)
Removed the checkbox on Asset List

