### PR TITLE
Update WalletSigner.tsx to fix the closing of the modal after broadcast

### DIFF
--- a/src/app/wallets/WalletSigner.tsx
+++ b/src/app/wallets/WalletSigner.tsx
@@ -9,6 +9,7 @@ import { KeplrConnect } from "./KeplrConnect";
 import { MetamaskConnect } from "./MetamaskConnect";
 import { PeraConnect } from "./PeraConnect";
 import { WalletName } from "./types";
+import { Modal } from "~/components/ui/modal"; // Import the Modal component
 
 export const WalletSigner = ({ onNextStep }: { onNextStep: () => void }) => {
   const { transaction, transactionHash, setTransactionHash } = useTransaction();
@@ -46,32 +47,36 @@ export const WalletSigner = ({ onNextStep }: { onNextStep: () => void }) => {
     }
   };
 
+  const handleClose = () => {
+    onNextStep();
+    setTransactionHash(undefined);
+  };
+
   if (transactionHash) {
     return (
-      <div className="p-12 py-2 flex flex-col gap-6 items-center">
-        <h1 className="font-extrabold text-2xl text-center mb-4">
-          Transaction successfully broadcasted
-        </h1>
-        <div>
-          <Rocket height={32} width={32} />
-        </div>
-        <div className="flex gap-4">
-          <Button onClick={handleCopyToClipboard}>Copy Tx Hash</Button>
-          <Button
-            onClick={() => {
-              onNextStep();
-              setTransactionHash(undefined);
-            }}
-          >
-            Close
-          </Button>
-        </div>
-      </div>
+      <Modal
+        open={true}
+        setOpen={() => handleClose()}
+        modalContent={
+          <div className="p-12 py-2 flex flex-col gap-6 items-center">
+            <h1 className="font-extrabold text-2xl text-center mb-4">
+              Transaction successfully broadcasted
+            </h1>
+            <div>
+              <Rocket height={32} width={32} />
+            </div>
+            <div className="flex gap-4">
+              <Button onClick={handleCopyToClipboard}>Copy Tx Hash</Button>
+              <Button onClick={handleClose}>Close</Button>
+            </div>
+          </div>
+        }
+      />
     );
   }
 
   if (transaction?.signature) {
-    return <BroadcastModal onNextStep={() => onNextStep()} />;
+    return <BroadcastModal onNextStep={onNextStep} />;
   }
 
   return (


### PR DESCRIPTION
Passing the handleClose function: The WalletSigner component passes the handleClose function to the Modal component via the setOpen prop.

Triggering handleClose: When the DialogClose button (the red cross) is clicked in the Modal component, it triggers the setOpen function passed down from WalletSigner, which, in turn, triggers handleClose.