### PR TITLE
Fix Tooltip Content Duplication on Copy

### DIFF
--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { cn } from "~/utils/helper";
 import { TableCell } from "./table";
+import { useEffect, useRef } from "react";
 
 const TooltipProvider = TooltipPrimitive.Provider;
 
@@ -53,13 +54,46 @@ const TableCellWithTooltip = ({
 }: {
   children: React.ReactNode;
   text: string;
-}) => (
-  <TableCell>
-    <CustomTooltip text={text}>
-      <TooltipTrigger>{children}</TooltipTrigger>
-    </CustomTooltip>
-  </TableCell>
-);
+}) => {
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleCopy = (event: ClipboardEvent) => {
+      if (
+        tooltipRef.current &&
+        tooltipRef.current.contains(event.target as Node)
+      ) {
+        event.preventDefault();
+        event.clipboardData?.setData("text/plain", text);
+      }
+    };
+
+    document.addEventListener("copy", handleCopy);
+
+    return () => {
+      document.removeEventListener("copy", handleCopy);
+    };
+  }, [text]);
+
+  return (
+    <TableCell>
+      <TooltipProvider>
+        <TooltipPrimitive.Root delayDuration={100}>
+          <TooltipTrigger asChild>
+            <span>{children}</span>
+          </TooltipTrigger>
+          <TooltipContent
+            sideOffset={4}
+            ref={tooltipRef}
+            className="whitespace-pre-line z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md"
+          >
+            {text}
+          </TooltipContent>
+        </TooltipPrimitive.Root>
+      </TooltipProvider>
+    </TableCell>
+  );
+};
 
 export {
   TooltipTrigger,


### PR DESCRIPTION
Description of Changes

This PR resolves an issue where copying text from a tooltip resulted in the content being duplicated in the clipboard. The duplication occurred because both the tooltip content and the surrounding DOM elements were being captured during the copy operation.

Context and Previous Attempts:

1. Initial Approach: We initially attempted to resolve the issue by restructuring the TooltipTrigger and TooltipContent components. The goal was to separate the tooltip content from the visible text to prevent duplication. However, this approach was insufficient as the underlying DOM structure still caused both elements to be copied together.
2. CSS-Based Solution: Another approach involved using user-select: none; on non-tooltip elements to prevent them from being copied. While this helped isolate the tooltip content, it didn’t fully eliminate the duplication issue, as the browser’s default copy behavior still included the tooltip content twice.
3. **Manual Clipboard Management**: Finally, we implemented manual clipboard management by intercepting the copy event using a useRef to track the tooltip content. This approach ensures that only the tooltip content is copied to the clipboard, addressing the root cause of the duplication.