### PR TITLE
Adv 334 remove asset selection from staking flows use staking position instead

### DIFF
--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -173,11 +173,14 @@ export function StakingTransactionForm({
       <h1 className="font-bold text-xl text-center">{label}</h1>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8 px-4">
-          <AssetFormField
-            form={form}
-            assets={assets}
-            setDecimals={setDecimals}
-          />
+          {/* Only show AssetFormField for delegation */}
+          {mode === TransactionMode.DELEGATE && (
+            <AssetFormField
+              form={form}
+              assets={assets}
+              setDecimals={setDecimals}
+            />
+          )}
 
           <SenderFormField form={form} />
 

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -78,6 +78,11 @@ export function StakingTransactionForm({
 
   const onSubmit = useCallback(
     (formInput: TransactionFormInput) => {
+      // Reset transaction and errors before initiating a new transaction
+      setTransaction(undefined);
+      setTransactionHash(undefined);
+      setErrors("");
+
       const transactionData: TransactionData = {
         mode,
         chainId: formInput.chainId,

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -78,6 +78,8 @@ export function StakingTransactionForm({
 
   const onSubmit = useCallback(
     (formInput: TransactionFormInput) => {
+      console.log("Form submitted with input:", formInput); // Log form input
+
       const transactionData: TransactionData = {
         mode,
         chainId: formInput.chainId,
@@ -95,6 +97,8 @@ export function StakingTransactionForm({
         );
       }
 
+      console.log("Transaction data before mutation:", transactionData); // Log transaction data
+
       // FIXME Hack to be able to provide the pubKey, probably better to refacto
       const pubKey = assets.find(
         (asset) => asset.address === formInput.sender
@@ -108,6 +112,7 @@ export function StakingTransactionForm({
 
       mutate(transactionData, {
         onSuccess: (settledTransaction) => {
+          console.log("Transaction success:", settledTransaction); // Log success response
           setTransaction(undefined);
           setTransactionHash(undefined);
           if (settledTransaction) {
@@ -116,14 +121,20 @@ export function StakingTransactionForm({
               settledTransaction.status.errors.length > 0
             ) {
               setErrors(settledTransaction.status.errors[0].message);
+              console.log(
+                "Transaction error message:",
+                settledTransaction.status.errors[0].message
+              ); // Log any errors returned from the transaction
             } else {
               setTransaction(settledTransaction);
             }
           } else {
             setErrors("API ERROR - Please try again later");
+            console.log("API ERROR - Please try again later"); // Log general error
           }
         },
         onError: (error) => {
+          console.log("Transaction error:", error.message); // Log error message
           setTransaction(undefined);
           setTransactionHash(undefined);
           setErrors(error.message);
@@ -138,6 +149,7 @@ export function StakingTransactionForm({
   }
 
   if (isSuccess && transaction) {
+    console.log("Transaction is ready:", transaction); // Log ready transaction
     return (
       <>
         <h1 className="font-bold text-xl text-center">

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -182,7 +182,8 @@ export function StakingTransactionForm({
             />
           )}
 
-          <SenderFormField form={form} />
+          {/* Only show SenderFormField for delegation */}
+          {mode === TransactionMode.DELEGATE && <SenderFormField form={form} />}
 
           {mode === TransactionMode.DELEGATE && (
             <ValidatorFormField

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -38,10 +38,6 @@ type StakingTransactionProps = {
   onNextStep: () => void;
 };
 
-// TODO Only works for Cosmos !!! API abstraction still needed
-
-// FIXME Some duplicate logic to put in common with ./TransferTransactionForm.tsx
-
 export function StakingTransactionForm({
   mode,
   assets,
@@ -107,7 +103,7 @@ export function StakingTransactionForm({
       // Handle auto-setting of sender for unstake or claim rewards based on selected staking position
       if (mode !== TransactionMode.DELEGATE && selectedStakingPosition) {
         console.log("Selected staking position:", selectedStakingPosition); // Log the selected staking position
-        transactionData.sender = selectedStakingPosition.addresses[0]; // Use the first address in the array for sender
+        transactionData.sender = selectedStakingPosition.addresses[0]; // Automatically use the first address
         console.log(
           "Auto-determined sender from staking position:",
           transactionData.sender
@@ -159,7 +155,13 @@ export function StakingTransactionForm({
   const handleStakingPositionChange = (stakingPosition: StakingPosition) => {
     console.log("Staking position selected:", stakingPosition);
     setSelectedStakingPosition(stakingPosition); // Track the selected staking position
-    form.setValue("sender", stakingPosition.addresses[0]); // Set the sender value based on the staking position's address
+    if (
+      mode === TransactionMode.UNDELEGATE ||
+      mode === TransactionMode.CLAIM_REWARDS
+    ) {
+      form.setValue("sender", stakingPosition.addresses[0]); // Auto-fill sender for unstake/claim
+      console.log("Sender set to:", stakingPosition.addresses[0]);
+    }
   };
 
   const handleError = (errors: any) => {

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -65,6 +65,9 @@ export function StakingTransactionForm({
   const { transaction, setTransaction, setTransactionHash } = useTransaction();
   const [errors, setErrors] = useState("");
 
+  // Debugging: Log any form errors immediately
+  console.log("Form errors:", form.formState.errors);
+
   const label = useMemo(() => {
     switch (mode) {
       case TransactionMode.DELEGATE:
@@ -78,6 +81,7 @@ export function StakingTransactionForm({
 
   const onSubmit = useCallback(
     (formInput: TransactionFormInput) => {
+      console.log("Submit handler triggered"); // Log when submit is triggered
       console.log("Form submitted with input:", formInput); // Log form input
 
       const transactionData: TransactionData = {
@@ -144,6 +148,10 @@ export function StakingTransactionForm({
     [assets, decimals, mode, mutate, setTransaction, setTransactionHash]
   );
 
+  const handleError = (errors: any) => {
+    console.log("Form validation failed:", errors); // Log validation errors
+  };
+
   if (isPending) {
     return <TransactionLoading />;
   }
@@ -184,7 +192,10 @@ export function StakingTransactionForm({
     <>
       <h1 className="font-bold text-xl text-center">{label}</h1>
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8 px-4">
+        <form
+          onSubmit={form.handleSubmit(onSubmit, handleError)}
+          className="space-y-8 px-4"
+        >
           {/* Only show AssetFormField for delegation */}
           {mode === TransactionMode.DELEGATE && (
             <AssetFormField
@@ -217,6 +228,22 @@ export function StakingTransactionForm({
           {(mode === TransactionMode.DELEGATE ||
             mode === TransactionMode.UNDELEGATE) && (
             <AmountFormField form={form} />
+          )}
+
+          {form.formState.errors && (
+            <div className="text-red-500">
+              {Object.keys(form.formState.errors).map((key) => {
+                const errorMessage =
+                  form.formState.errors[
+                    key as keyof typeof form.formState.errors
+                  ]?.message;
+                return (
+                  <div key={key}>
+                    Error in {key}: {errorMessage}
+                  </div>
+                );
+              })}
+            </div>
           )}
 
           {errors && (

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -38,6 +38,10 @@ type StakingTransactionProps = {
   onNextStep: () => void;
 };
 
+// TODO Only works for Cosmos !!! API abstraction still needed
+
+// FIXME Some duplicate logic to put in common with ./TransferTransactionForm.tsx
+
 export function StakingTransactionForm({
   mode,
   assets,
@@ -103,7 +107,7 @@ export function StakingTransactionForm({
       // Handle auto-setting of sender for unstake or claim rewards based on selected staking position
       if (mode !== TransactionMode.DELEGATE && selectedStakingPosition) {
         console.log("Selected staking position:", selectedStakingPosition); // Log the selected staking position
-        transactionData.sender = selectedStakingPosition.addresses[0]; // Automatically use the first address
+        transactionData.sender = selectedStakingPosition.addresses[0]; // Use the first address in the array for sender
         console.log(
           "Auto-determined sender from staking position:",
           transactionData.sender
@@ -155,13 +159,7 @@ export function StakingTransactionForm({
   const handleStakingPositionChange = (stakingPosition: StakingPosition) => {
     console.log("Staking position selected:", stakingPosition);
     setSelectedStakingPosition(stakingPosition); // Track the selected staking position
-    if (
-      mode === TransactionMode.UNDELEGATE ||
-      mode === TransactionMode.CLAIM_REWARDS
-    ) {
-      form.setValue("sender", stakingPosition.addresses[0]); // Auto-fill sender for unstake/claim
-      console.log("Sender set to:", stakingPosition.addresses[0]);
-    }
+    form.setValue("sender", stakingPosition.addresses[0]); // Set the sender value based on the staking position's address
   };
 
   const handleError = (errors: any) => {

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -170,6 +170,16 @@ export function StakingTransactionForm({
   // Handle Staking Position change to auto-set sender
   const handleStakingPositionChange = (stakingPosition: StakingPosition) => {
     setSelectedStakingPosition(stakingPosition); // Track the selected staking position
+
+    // Find the associated asset based on the staking position (chainId or another identifier)
+    const associatedAsset = assets.find(
+      (asset) => asset.chainId === stakingPosition.chainId
+    );
+
+    if (associatedAsset) {
+      setDecimals(associatedAsset.decimals); // Set decimals from the asset
+    }
+
     if (
       mode === TransactionMode.UNDELEGATE ||
       mode === TransactionMode.CLAIM_REWARDS
@@ -249,6 +259,7 @@ export function StakingTransactionForm({
               stakingPositions={stakingPositions}
               validators={validators}
               onStakingPositionChange={handleStakingPositionChange} // Pass the handler to track the selected staking position
+              setDecimals={setDecimals}
             />
           )}
 

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -65,8 +65,9 @@ export function StakingTransactionForm({
   const { transaction, setTransaction, setTransactionHash } = useTransaction();
   const [errors, setErrors] = useState("");
 
-  // Debugging: Log any form errors immediately
-  console.log("Form errors:", form.formState.errors);
+  // Add a state to keep track of the selected staking position
+  const [selectedStakingPosition, setSelectedStakingPosition] =
+    useState<StakingPosition | null>(null);
 
   const label = useMemo(() => {
     switch (mode) {
@@ -81,13 +82,13 @@ export function StakingTransactionForm({
 
   const onSubmit = useCallback(
     (formInput: TransactionFormInput) => {
-      console.log("Submit handler triggered"); // Log when submit is triggered
-      console.log("Form submitted with input:", formInput); // Log form input
+      console.log("Submit handler triggered");
+      console.log("Form submitted with input:", formInput);
 
       const transactionData: TransactionData = {
         mode,
         chainId: formInput.chainId,
-        sender: formInput.sender,
+        sender: formInput.sender || "", // If unstaking, sender can be derived from the staking position
         recipient: "",
         validatorAddress: formInput.validatorAddress ?? "",
         useMaxAmount: formInput.useMaxAmount,
@@ -101,22 +102,21 @@ export function StakingTransactionForm({
         );
       }
 
-      console.log("Transaction data before mutation:", transactionData); // Log transaction data
+      console.log("Transaction data before mutation:", transactionData);
 
-      // FIXME Hack to be able to provide the pubKey, probably better to refacto
-      const pubKey = assets.find(
-        (asset) => asset.address === formInput.sender
-      )?.pubKey;
-
-      if (pubKey) {
-        transactionData.params = {
-          pubKey,
-        };
+      // Handle auto-setting of sender for unstake or claim rewards based on selected staking position
+      if (mode !== TransactionMode.DELEGATE && selectedStakingPosition) {
+        console.log("Selected staking position:", selectedStakingPosition); // Log the selected staking position
+        transactionData.sender = selectedStakingPosition.addresses[0]; // Use the first address in the array for sender
+        console.log(
+          "Auto-determined sender from staking position:",
+          transactionData.sender
+        );
       }
 
       mutate(transactionData, {
         onSuccess: (settledTransaction) => {
-          console.log("Transaction success:", settledTransaction); // Log success response
+          console.log("Transaction success:", settledTransaction);
           setTransaction(undefined);
           setTransactionHash(undefined);
           if (settledTransaction) {
@@ -128,28 +128,42 @@ export function StakingTransactionForm({
               console.log(
                 "Transaction error message:",
                 settledTransaction.status.errors[0].message
-              ); // Log any errors returned from the transaction
+              );
             } else {
               setTransaction(settledTransaction);
             }
           } else {
             setErrors("API ERROR - Please try again later");
-            console.log("API ERROR - Please try again later"); // Log general error
+            console.log("API ERROR - Please try again later");
           }
         },
         onError: (error) => {
-          console.log("Transaction error:", error.message); // Log error message
+          console.log("Transaction error:", error.message);
           setTransaction(undefined);
           setTransactionHash(undefined);
           setErrors(error.message);
         },
       });
     },
-    [assets, decimals, mode, mutate, setTransaction, setTransactionHash]
+    [
+      assets,
+      decimals,
+      mode,
+      mutate,
+      selectedStakingPosition,
+      setTransaction,
+      setTransactionHash,
+    ]
   );
 
+  const handleStakingPositionChange = (stakingPosition: StakingPosition) => {
+    console.log("Staking position selected:", stakingPosition);
+    setSelectedStakingPosition(stakingPosition); // Track the selected staking position
+    form.setValue("sender", stakingPosition.addresses[0]); // Set the sender value based on the staking position's address
+  };
+
   const handleError = (errors: any) => {
-    console.log("Form validation failed:", errors); // Log validation errors
+    console.log("Form validation failed:", errors);
   };
 
   if (isPending) {
@@ -157,7 +171,7 @@ export function StakingTransactionForm({
   }
 
   if (isSuccess && transaction) {
-    console.log("Transaction is ready:", transaction); // Log ready transaction
+    console.log("Transaction is ready:", transaction);
     return (
       <>
         <h1 className="font-bold text-xl text-center">
@@ -196,7 +210,6 @@ export function StakingTransactionForm({
           onSubmit={form.handleSubmit(onSubmit, handleError)}
           className="space-y-8 px-4"
         >
-          {/* Only show AssetFormField for delegation */}
           {mode === TransactionMode.DELEGATE && (
             <AssetFormField
               form={form}
@@ -205,7 +218,6 @@ export function StakingTransactionForm({
             />
           )}
 
-          {/* Only show SenderFormField for delegation */}
           {mode === TransactionMode.DELEGATE && <SenderFormField form={form} />}
 
           {mode === TransactionMode.DELEGATE && (
@@ -222,6 +234,7 @@ export function StakingTransactionForm({
               form={form}
               stakingPositions={stakingPositions}
               validators={validators}
+              onStakingPositionChange={handleStakingPositionChange} // Pass handler to track selected staking position
             />
           )}
 
@@ -232,17 +245,15 @@ export function StakingTransactionForm({
 
           {form.formState.errors && (
             <div className="text-red-500">
-              {Object.keys(form.formState.errors).map((key) => {
-                const errorMessage =
-                  form.formState.errors[
-                    key as keyof typeof form.formState.errors
-                  ]?.message;
-                return (
-                  <div key={key}>
-                    Error in {key}: {errorMessage}
-                  </div>
-                );
-              })}
+              {(
+                Object.keys(form.formState.errors) as Array<
+                  keyof typeof form.formState.errors
+                >
+              ).map((key) => (
+                <div key={key}>
+                  Error in {key}: {form.formState.errors[key]?.message}
+                </div>
+              ))}
             </div>
           )}
 

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -93,6 +93,22 @@ export function StakingTransactionForm({
         format: "json", // FIXME Not always the default, should come from chains config
       };
 
+      // Handle auto-setting of sender for unstake or claim rewards based on selected staking position
+      if (
+        (mode === TransactionMode.UNDELEGATE ||
+          mode === TransactionMode.CLAIM_REWARDS) &&
+        formInput.validatorAddress // Ensure validatorAddress is defined
+      ) {
+        const selectedStakingPosition =
+          stakingPositions[formInput.validatorAddress];
+        if (
+          selectedStakingPosition &&
+          selectedStakingPosition.addresses.length > 0
+        ) {
+          transactionData.sender = selectedStakingPosition.addresses[0]; // Automatically use the first address
+        }
+      }
+
       if (formInput.amount && !formInput.useMaxAmount) {
         transactionData.amount = amountToSmallestUnit(
           formInput.amount.toString(),
@@ -135,7 +151,15 @@ export function StakingTransactionForm({
         },
       });
     },
-    [assets, decimals, mode, mutate, setTransaction, setTransactionHash]
+    [
+      assets,
+      decimals,
+      mode,
+      mutate,
+      setTransaction,
+      setTransactionHash,
+      stakingPositions,
+    ]
   );
 
   if (isPending) {

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -78,8 +78,6 @@ export function StakingTransactionForm({
 
   const onSubmit = useCallback(
     (formInput: TransactionFormInput) => {
-      console.log("Form submitted with input:", formInput); // Log form input
-
       const transactionData: TransactionData = {
         mode,
         chainId: formInput.chainId,
@@ -97,8 +95,6 @@ export function StakingTransactionForm({
         );
       }
 
-      console.log("Transaction data before mutation:", transactionData); // Log transaction data
-
       // FIXME Hack to be able to provide the pubKey, probably better to refacto
       const pubKey = assets.find(
         (asset) => asset.address === formInput.sender
@@ -112,7 +108,6 @@ export function StakingTransactionForm({
 
       mutate(transactionData, {
         onSuccess: (settledTransaction) => {
-          console.log("Transaction success:", settledTransaction); // Log success response
           setTransaction(undefined);
           setTransactionHash(undefined);
           if (settledTransaction) {
@@ -121,20 +116,14 @@ export function StakingTransactionForm({
               settledTransaction.status.errors.length > 0
             ) {
               setErrors(settledTransaction.status.errors[0].message);
-              console.log(
-                "Transaction error message:",
-                settledTransaction.status.errors[0].message
-              ); // Log any errors returned from the transaction
             } else {
               setTransaction(settledTransaction);
             }
           } else {
             setErrors("API ERROR - Please try again later");
-            console.log("API ERROR - Please try again later"); // Log general error
           }
         },
         onError: (error) => {
-          console.log("Transaction error:", error.message); // Log error message
           setTransaction(undefined);
           setTransactionHash(undefined);
           setErrors(error.message);
@@ -149,7 +138,6 @@ export function StakingTransactionForm({
   }
 
   if (isSuccess && transaction) {
-    console.log("Transaction is ready:", transaction); // Log ready transaction
     return (
       <>
         <h1 className="font-bold text-xl text-center">

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -62,8 +62,9 @@ export function StakingTransactionForm({
   const [decimals, setDecimals] = useState<number>(0);
   const { transaction, setTransaction, setTransactionHash } = useTransaction();
   const [errors, setErrors] = useState("");
-  const [selectedStakingPosition, setSelectedStakingPosition] =
-    useState<StakingPosition | null>(null);
+  const [selectedStakingPosition, setSelectedStakingPosition] = useState<
+    StakingPosition | undefined
+  >();
   const prevStakingPositionRef = useRef<StakingPosition | null>(null);
 
   const label = useMemo(() => {

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -65,9 +65,6 @@ export function StakingTransactionForm({
   const { transaction, setTransaction, setTransactionHash } = useTransaction();
   const [errors, setErrors] = useState("");
 
-  // Debugging: Log any form errors immediately
-  console.log("Form errors:", form.formState.errors);
-
   const label = useMemo(() => {
     switch (mode) {
       case TransactionMode.DELEGATE:
@@ -81,7 +78,6 @@ export function StakingTransactionForm({
 
   const onSubmit = useCallback(
     (formInput: TransactionFormInput) => {
-      console.log("Submit handler triggered"); // Log when submit is triggered
       console.log("Form submitted with input:", formInput); // Log form input
 
       const transactionData: TransactionData = {
@@ -148,10 +144,6 @@ export function StakingTransactionForm({
     [assets, decimals, mode, mutate, setTransaction, setTransactionHash]
   );
 
-  const handleError = (errors: any) => {
-    console.log("Form validation failed:", errors); // Log validation errors
-  };
-
   if (isPending) {
     return <TransactionLoading />;
   }
@@ -192,10 +184,7 @@ export function StakingTransactionForm({
     <>
       <h1 className="font-bold text-xl text-center">{label}</h1>
       <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit(onSubmit, handleError)}
-          className="space-y-8 px-4"
-        >
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8 px-4">
           {/* Only show AssetFormField for delegation */}
           {mode === TransactionMode.DELEGATE && (
             <AssetFormField
@@ -228,22 +217,6 @@ export function StakingTransactionForm({
           {(mode === TransactionMode.DELEGATE ||
             mode === TransactionMode.UNDELEGATE) && (
             <AmountFormField form={form} />
-          )}
-
-          {form.formState.errors && (
-            <div className="text-red-500">
-              {Object.keys(form.formState.errors).map((key) => {
-                const errorMessage =
-                  form.formState.errors[
-                    key as keyof typeof form.formState.errors
-                  ]?.message;
-                return (
-                  <div key={key}>
-                    Error in {key}: {errorMessage}
-                  </div>
-                );
-              })}
-            </div>
           )}
 
           {errors && (

--- a/src/app/transactions/fields/AssetFormField.tsx
+++ b/src/app/transactions/fields/AssetFormField.tsx
@@ -40,6 +40,11 @@ export function AssetFormField({
                 form.setValue("assetIndex", index);
                 form.setValue("chainId", asset.chainId);
                 form.setValue("sender", asset.address);
+
+                // Clear the validator-related fields
+                form.setValue("validatorIndex", undefined);
+                form.setValue("validatorAddress", "");
+
                 if (asset.isToken) {
                   form.setValue("mode", TransactionMode.TRANSFER_TOKEN);
                   form.setValue(
@@ -47,8 +52,6 @@ export function AssetFormField({
                     asset.contractAddress || asset.assetId
                   );
                 }
-                form.resetField("validatorIndex");
-                form.resetField("validatorAddress");
                 setDecimals(asset.decimals);
               }}
               {...field}

--- a/src/app/transactions/fields/StakingPositionFormField.tsx
+++ b/src/app/transactions/fields/StakingPositionFormField.tsx
@@ -16,12 +16,14 @@ type StakingPositionFormFieldProps = {
   stakingPositions: Record<string, StakingPosition>;
   validators: Validator[];
   //setDecimals: (decimals: number) => void;
+  onStakingPositionChange: (stakingPosition: StakingPosition) => void; // Add this line
 };
 
 export function StakingPositionFormField({
   form,
   stakingPositions,
   validators,
+  onStakingPositionChange, // Include the onStakingPositionChange prop here
 }: StakingPositionFormFieldProps) {
   return (
     <FormField
@@ -60,6 +62,7 @@ export function StakingPositionFormField({
                     stakingPosition.validatorAddresses[0]
                   );
                   //setDecimals(stakingPosition.decimals);
+                  onStakingPositionChange(stakingPosition); // Trigger the prop passed to the component
                 }}
                 {...field}
               />

--- a/src/app/transactions/fields/StakingPositionFormField.tsx
+++ b/src/app/transactions/fields/StakingPositionFormField.tsx
@@ -15,15 +15,15 @@ type StakingPositionFormFieldProps = {
   form: UseFormReturn<TransactionFormInput>;
   stakingPositions: Record<string, StakingPosition>;
   validators: Validator[];
-  //setDecimals: (decimals: number) => void;
-  onStakingPositionChange: (stakingPosition: StakingPosition) => void; // Add this line
+  setDecimals: (decimals: number) => void; // Ensure this prop is used
+  onStakingPositionChange: (stakingPosition: StakingPosition) => void;
 };
 
 export function StakingPositionFormField({
   form,
   stakingPositions,
   validators,
-  onStakingPositionChange, // Include the onStakingPositionChange prop here
+  onStakingPositionChange,
 }: StakingPositionFormFieldProps) {
   return (
     <FormField
@@ -61,8 +61,9 @@ export function StakingPositionFormField({
                     "validatorAddress",
                     stakingPosition.validatorAddresses[0]
                   );
-                  //setDecimals(stakingPosition.decimals);
-                  onStakingPositionChange(stakingPosition); // Trigger the prop passed to the component
+
+                  // Trigger the prop passed to the component
+                  onStakingPositionChange(stakingPosition);
                 }}
                 {...field}
               />

--- a/src/app/transactions/fields/StakingPositionFormField.tsx
+++ b/src/app/transactions/fields/StakingPositionFormField.tsx
@@ -15,13 +15,14 @@ type StakingPositionFormFieldProps = {
   form: UseFormReturn<TransactionFormInput>;
   stakingPositions: Record<string, StakingPosition>;
   validators: Validator[];
-  //setDecimals: (decimals: number) => void;
+  onStakingPositionChange?: (stakingPosition: StakingPosition) => void; // Add this prop for notifying parent
 };
 
 export function StakingPositionFormField({
   form,
   stakingPositions,
   validators,
+  onStakingPositionChange, // Destructure the new prop
 }: StakingPositionFormFieldProps) {
   return (
     <FormField
@@ -53,13 +54,18 @@ export function StakingPositionFormField({
                     : undefined
                 }
                 onSelect={(stakingPosition, index) => {
+                  // Set values in the form when a position is selected
                   form.setValue("stakingPositionIndex", index);
                   form.setValue("chainId", stakingPosition.chainId);
                   form.setValue(
                     "validatorAddress",
                     stakingPosition.validatorAddresses[0]
                   );
-                  //setDecimals(stakingPosition.decimals);
+
+                  // Call the callback prop to notify parent if provided
+                  if (onStakingPositionChange) {
+                    onStakingPositionChange(stakingPosition);
+                  }
                 }}
                 {...field}
               />

--- a/src/app/transactions/fields/StakingPositionFormField.tsx
+++ b/src/app/transactions/fields/StakingPositionFormField.tsx
@@ -35,18 +35,10 @@ export function StakingPositionFormField({
             <FormLabel>Positions</FormLabel>
             <FormControl>
               <StakingPositionSelector
-                validators={validators.filter((validator) => {
-                  const chainId = form.watch("chainId");
-                  return chainId === "" ? true : validator.chainId === chainId;
-                })}
-                stakingPositions={Object.values(stakingPositions).filter(
-                  (stakingPosition) => {
-                    const chainId = form.watch("chainId");
-                    return chainId === ""
-                      ? true
-                      : stakingPosition.chainId === chainId;
-                  }
-                )}
+                // Remove filtering for validators
+                validators={validators}
+                // Remove filtering for staking positions
+                stakingPositions={Object.values(stakingPositions)}
                 selectedValue={
                   form.getValues().stakingPositionIndex
                     ? stakingPositions[

--- a/src/app/transactions/fields/StakingPositionFormField.tsx
+++ b/src/app/transactions/fields/StakingPositionFormField.tsx
@@ -15,14 +15,13 @@ type StakingPositionFormFieldProps = {
   form: UseFormReturn<TransactionFormInput>;
   stakingPositions: Record<string, StakingPosition>;
   validators: Validator[];
-  onStakingPositionChange?: (stakingPosition: StakingPosition) => void; // Add this prop for notifying parent
+  //setDecimals: (decimals: number) => void;
 };
 
 export function StakingPositionFormField({
   form,
   stakingPositions,
   validators,
-  onStakingPositionChange, // Destructure the new prop
 }: StakingPositionFormFieldProps) {
   return (
     <FormField
@@ -54,18 +53,13 @@ export function StakingPositionFormField({
                     : undefined
                 }
                 onSelect={(stakingPosition, index) => {
-                  // Set values in the form when a position is selected
                   form.setValue("stakingPositionIndex", index);
                   form.setValue("chainId", stakingPosition.chainId);
                   form.setValue(
                     "validatorAddress",
                     stakingPosition.validatorAddresses[0]
                   );
-
-                  // Call the callback prop to notify parent if provided
-                  if (onStakingPositionChange) {
-                    onStakingPositionChange(stakingPosition);
-                  }
+                  //setDecimals(stakingPosition.decimals);
                 }}
                 {...field}
               />

--- a/src/app/transactions/fields/ValidatorFormField.tsx
+++ b/src/app/transactions/fields/ValidatorFormField.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect } from "react";
 import { UseFormReturn } from "react-hook-form";
 import { ValidatorSelector } from "~/app/stake/ValidatorSelector";
 import {
@@ -21,6 +22,15 @@ export function ValidatorFormField({
   validators,
   setDecimals,
 }: ValidatorFormFieldProps) {
+  // Watch the chainId to trigger re-render
+  const chainId = form.watch("chainId");
+
+  // Log chainId and validatorIndex to track changes
+  useEffect(() => {
+    console.log("Current chainId (or assetId):", chainId);
+    console.log("Current validator index:", form.getValues("validatorIndex"));
+  }, [chainId, form]);
+
   return (
     <FormField
       control={form.control}
@@ -30,9 +40,10 @@ export function ValidatorFormField({
           <>
             <FormLabel>Validators</FormLabel>
             <FormControl>
+              {/* Add key to ValidatorSelector to force remount when chainId changes */}
               <ValidatorSelector
+                key={chainId} // Force re-render on chainId change
                 validators={validators.filter((validator) => {
-                  const chainId = form.watch("chainId");
                   return chainId === "" ? true : validator.chainId === chainId;
                 })}
                 selectedValue={
@@ -45,6 +56,7 @@ export function ValidatorFormField({
                   form.setValue("chainId", validator.chainId);
                   form.setValue("validatorAddress", validator.address);
                   setDecimals(validator.decimals);
+                  console.log("Selected validator index:", index);
                 }}
                 {...field}
               />

--- a/src/app/transactions/fields/ValidatorFormField.tsx
+++ b/src/app/transactions/fields/ValidatorFormField.tsx
@@ -25,9 +25,6 @@ export function ValidatorFormField({
   // Watch the chainId to trigger re-render
   const chainId = form.watch("chainId");
 
-  // Log chainId and validatorIndex to track changes
-  useEffect(() => {}, [chainId, form]);
-
   return (
     <FormField
       control={form.control}

--- a/src/app/transactions/fields/ValidatorFormField.tsx
+++ b/src/app/transactions/fields/ValidatorFormField.tsx
@@ -26,10 +26,7 @@ export function ValidatorFormField({
   const chainId = form.watch("chainId");
 
   // Log chainId and validatorIndex to track changes
-  useEffect(() => {
-    console.log("Current chainId (or assetId):", chainId);
-    console.log("Current validator index:", form.getValues("validatorIndex"));
-  }, [chainId, form]);
+  useEffect(() => {}, [chainId, form]);
 
   return (
     <FormField
@@ -56,7 +53,6 @@ export function ValidatorFormField({
                   form.setValue("chainId", validator.chainId);
                   form.setValue("validatorAddress", validator.address);
                   setDecimals(validator.decimals);
-                  console.log("Selected validator index:", index);
                 }}
                 {...field}
               />


### PR DESCRIPTION
1) The user only has to select the Staking Position when unstaking and claiming (chaindId, sender address, etc... all relevant information are derived from the staking position)
2) The user can still set an amount to undelegate (unlike claiming which is all or nothing)
3) many small bug fix for instance: £
- if users ends the flow before completing it entirely, then the flow is reset (not for later: we don't handle well the case where the signature is requested by the signer, but then the flow is stopped // I'll tackle it later)
- resetting validator selected to undefined if the user changes the asset he wants to delegate from (took me long time)
- avoid filtering staking position (based on chainId) once a first staking position has been selected (really didn't make sense)