### PR TITLE
Adv 333 after partially unstaking a cosmos delegation remaining delegation isn t visible

### DIFF
--- a/src/app/stake/StakingPositionSelector.tsx
+++ b/src/app/stake/StakingPositionSelector.tsx
@@ -127,23 +127,25 @@ const StakingPositionSelectorList = ({
         <CommandEmpty>No results found.</CommandEmpty>
         <ScrollArea className="h-[240px] overflow-auto">
           <CommandGroup>
-            {stakingPositions.map((stakingPosition, i) => (
-              <CommandItem
-                key={`${stakingPosition.validatorAddresses[0]}_${i}`}
-                value={`${stakingPosition.validatorName}_${i.toString()}`}
-                onSelect={(value) => {
-                  const [name, index] = value.split("_");
-                  setSelectedChoice(stakingPositions[Number(index)]);
-                  setOpen(false);
-                  onSelect(stakingPosition, i);
-                }}
-              >
-                <StakingPositionView
-                  stakingPosition={stakingPosition}
-                  validators={validators}
-                />
-              </CommandItem>
-            ))}
+            {stakingPositions
+              .filter((position) => position.status !== "unlocking") // Filtering logic
+              .map((stakingPosition, i) => (
+                <CommandItem
+                  key={`${stakingPosition.validatorAddresses[0]}_${i}`}
+                  value={`${stakingPosition.validatorName}_${i.toString()}`}
+                  onSelect={(value) => {
+                    const [name, index] = value.split("_");
+                    setSelectedChoice(stakingPositions[Number(index)]);
+                    setOpen(false);
+                    onSelect(stakingPosition, i);
+                  }}
+                >
+                  <StakingPositionView
+                    stakingPosition={stakingPosition}
+                    validators={validators}
+                  />
+                </CommandItem>
+              ))}
           </CommandGroup>
         </ScrollArea>
       </CommandList>

--- a/src/app/stake/helpers.ts
+++ b/src/app/stake/helpers.ts
@@ -140,7 +140,6 @@ export const getAddressStakingPositions = (
       );
       if (!chainDetails) return newAcc;
 
-      // Iterate over staking positions
       (accountData?.balances.staking?.positions || []).forEach((position) => {
         position.validatorAddresses.forEach((validatorAddress) => {
           const validatorInfo = getValidatorInfo(
@@ -173,13 +172,13 @@ export const getAddressStakingPositions = (
               mobulaMarketData,
               chainDetails
             ),
-            status: position.status, // Important to keep track of the status
+            status: position.status,
             completionDate: position.completionDate, // If exists for 'unlocking' positions
           };
         });
       });
 
-      // Handle native rewards by merging them into the existing staking position
+      // Handle native rewards and merge them into the existing staking position
       (accountData?.balances.staking?.rewards.native || []).forEach(
         (reward) => {
           const uniqueKey = `${reward.validatorAddress}_locked`;
@@ -200,7 +199,7 @@ export const getAddressStakingPositions = (
         }
       );
 
-      // Handle token rewards by merging them into the existing staking position
+      // Handle token rewards and merge them into the existing staking position
       (accountData?.balances.staking?.rewards.tokens || []).forEach(
         (reward) => {
           if (

--- a/src/app/stake/helpers.ts
+++ b/src/app/stake/helpers.ts
@@ -153,6 +153,7 @@ export const getAddressStakingPositions = (
           const uniqueKey = `${validatorAddress}_${position.status}`;
 
           newAcc[uniqueKey] = {
+            ...newAcc[uniqueKey], // Keep existing data if already processed
             ...position,
             addresses: [accountData.accountId].concat(currentAddresses),
             validatorName: validatorInfo?.name,
@@ -178,26 +179,28 @@ export const getAddressStakingPositions = (
         });
       });
 
-      // Handle native rewards
+      // Handle native rewards by merging them into the existing staking position
       (accountData?.balances.staking?.rewards.native || []).forEach(
         (reward) => {
-          const uniqueKey = `${reward.validatorAddress}_rewards`;
+          const uniqueKey = `${reward.validatorAddress}_locked`;
 
-          newAcc[uniqueKey] = {
-            ...(newAcc[uniqueKey] || {}),
-            rewardAmount:
-              amountToMainUnit(reward.amount, chainDetails.decimals) || "-",
-            rewardAmountUSD: getAmountToUSD(
-              reward.amount,
-              chainDetails.decimals,
-              mobulaMarketData,
-              chainDetails
-            ),
-          };
+          if (newAcc[uniqueKey]) {
+            newAcc[uniqueKey] = {
+              ...newAcc[uniqueKey],
+              rewardAmount:
+                amountToMainUnit(reward.amount, chainDetails.decimals) || "-",
+              rewardAmountUSD: getAmountToUSD(
+                reward.amount,
+                chainDetails.decimals,
+                mobulaMarketData,
+                chainDetails
+              ),
+            };
+          }
         }
       );
 
-      // Handle token rewards
+      // Handle token rewards by merging them into the existing staking position
       (accountData?.balances.staking?.rewards.tokens || []).forEach(
         (reward) => {
           if (
@@ -224,15 +227,17 @@ export const getAddressStakingPositions = (
             },
           };
 
-          const uniqueKey = `${reward.validatorAddress}_tokens`;
+          const uniqueKey = `${reward.validatorAddress}_locked`;
 
-          newAcc[uniqueKey] = {
-            ...(newAcc[uniqueKey] || {}),
-            rewardTokens: [
-              ...(newAcc[uniqueKey]?.rewardTokens || []),
-              tokenAmount,
-            ],
-          };
+          if (newAcc[uniqueKey]) {
+            newAcc[uniqueKey] = {
+              ...newAcc[uniqueKey],
+              rewardTokens: [
+                ...(newAcc[uniqueKey]?.rewardTokens || []),
+                tokenAmount,
+              ],
+            };
+          }
         }
       );
 


### PR DESCRIPTION
BEFORE:<img width="1224" alt="Capture d’écran 2024-09-05 à 14 57 17" src="https://github.com/user-attachments/assets/cb9f1c7d-8d82-4e03-b0c3-f5200c950986">


AFTER:<img width="1257" alt="Capture d’écran 2024-09-05 à 14 56 57" src="https://github.com/user-attachments/assets/f73c85c7-d56f-42c8-864f-3e298bca8ec9">

Summary:
- [Add a way to differentiate two staking position based on the "status"](https://github.com/AdamikHQ/adamik-app/commit/ff8956680e6911e481b821e0c81a9c674f29bfd0)
- [Make sure to assign token reward to locked staking position (not unlo…](https://github.com/AdamikHQ/adamik-app/commit/4b524c55edc385f8f8d210d2065065c2f45edf18)
- [Filter out unlocking staking position from claim and unstake modal](https://github.com/AdamikHQ/adamik-app/commit/0496fdfef556c39ce214518e3e657fb25f0fad15)