### PR TITLE
Use chain logo instead of first letter of validator name

### DIFF
--- a/src/app/stake/StakingPositionSelector.tsx
+++ b/src/app/stake/StakingPositionSelector.tsx
@@ -22,6 +22,7 @@ import { ScrollArea } from "~/components/ui/scroll-area";
 import { Tooltip, TooltipTrigger } from "~/components/ui/tooltip";
 import { StakingPosition } from "./helpers";
 import { TransactionMode, Validator } from "~/utils/types";
+import { formatAmount } from "~/utils/helper";
 
 type StakingPositionSelectorProps = {
   stakingPositions: StakingPosition[];
@@ -46,7 +47,7 @@ export function StakingPositionSelector({
 
   const label =
     mode === TransactionMode.CLAIM_REWARDS
-      ? "Select a position to claim rewards"
+      ? "Select rewards to claim"
       : "Select a position";
 
   if (isDesktop) {
@@ -197,6 +198,17 @@ const StakingPositionView = ({
     );
   }, [stakingPosition, validators]);
 
+  // Define the threshold for showing rewards
+  const MIN_REWARD_THRESHOLD = 0.00001;
+
+  const formattedRewardAmount = stakingPosition.rewardAmount
+    ? parseFloat(stakingPosition.rewardAmount)
+    : 0;
+
+  const displayReward =
+    formattedRewardAmount >= MIN_REWARD_THRESHOLD
+      ? formatAmount(formattedRewardAmount, 3)
+      : `>${MIN_REWARD_THRESHOLD}`;
   return (
     validator && (
       <div className="flex items-center justify-between w-full">
@@ -219,10 +231,13 @@ const StakingPositionView = ({
         <div className="font-bold flex-1 text-right">
           {mode === TransactionMode.CLAIM_REWARDS ? (
             <>
-              {stakingPosition.rewardAmount
-                ? parseFloat(stakingPosition.rewardAmount).toFixed(3)
-                : "0"}{" "}
-              {stakingPosition.ticker} Rewards
+              {stakingPosition.rewardAmount ? (
+                <div>
+                  {displayReward} {stakingPosition.ticker}
+                </div>
+              ) : (
+                "0 Rewards"
+              )}
             </>
           ) : (
             <>

--- a/src/app/stake/StakingPositionSelector.tsx
+++ b/src/app/stake/StakingPositionSelector.tsx
@@ -179,28 +179,13 @@ const StakingPositionView = ({
             <Tooltip text={validator?.address}>
               <TooltipTrigger>
                 <Avatar className="w-[32px] h-[32px]">
-                  <AvatarFallback>
-                    {validator.name[0].toUpperCase() ||
-                      validator?.address[0].toUpperCase()}
-                  </AvatarFallback>
+                  <AvatarImage
+                    src={validator.chainLogo}
+                    alt={validator.chainId}
+                  />
                 </Avatar>
               </TooltipTrigger>
             </Tooltip>
-            {validator.chainLogo && (
-              <Tooltip text={validator.chainId}>
-                <TooltipTrigger>
-                  <div className="absolute w-4 h-4 text-xs font-bold text-primary bg-primary-foreground border-2 rounded-full -top-[6px] -end-1">
-                    <Avatar className="h-3 w-3">
-                      <AvatarImage
-                        src={validator.chainLogo}
-                        alt={validator.chainId}
-                      />
-                      <AvatarFallback>{validator.chainId}</AvatarFallback>
-                    </Avatar>
-                  </div>
-                </TooltipTrigger>
-              </Tooltip>
-            )}
           </div>
         )}
         <div className="flex-1 text-right">{validator.name}</div>

--- a/src/app/stake/StakingPositionSelector.tsx
+++ b/src/app/stake/StakingPositionSelector.tsx
@@ -190,8 +190,7 @@ const StakingPositionView = ({
         )}
         <div className="flex-1 text-right">{validator.name}</div>
         <div className="font-bold flex-1 text-right">
-          Stake: {stakingPosition.amount}
-          {/* FIXME Need to display the unit too */}
+          {stakingPosition.amount} {stakingPosition.ticker}
         </div>
       </div>
     )

--- a/src/app/stake/StakingPositionsList.tsx
+++ b/src/app/stake/StakingPositionsList.tsx
@@ -114,8 +114,6 @@ const StakingPositionsListRow: React.FC<{
                   }`}
                 </div>
               ))}
-
-              {/* Render a single line for small value tokens */}
               {/* Render a single line for small value tokens */}
               {smallTokenRewards.length > 0 && (
                 <div key="small-values">

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -238,6 +238,7 @@ export function StakingTransactionForm({
           {(mode === TransactionMode.UNDELEGATE ||
             mode === TransactionMode.CLAIM_REWARDS) && (
             <StakingPositionFormField
+              mode={mode}
               form={form}
               stakingPositions={stakingPositions}
               validators={validators}

--- a/src/app/transactions/StakingTransactionForm.tsx
+++ b/src/app/transactions/StakingTransactionForm.tsx
@@ -65,8 +65,6 @@ export function StakingTransactionForm({
   const [selectedStakingPosition, setSelectedStakingPosition] = useState<
     StakingPosition | undefined
   >();
-  const prevStakingPositionRef = useRef<StakingPosition | null>(null);
-
   const label = useMemo(() => {
     switch (mode) {
       case TransactionMode.DELEGATE:

--- a/src/app/transactions/fields/StakingPositionFormField.tsx
+++ b/src/app/transactions/fields/StakingPositionFormField.tsx
@@ -9,7 +9,7 @@ import {
   FormMessage,
 } from "~/components/ui/form";
 import { TransactionFormInput } from "~/utils/schema";
-import { Validator } from "~/utils/types";
+import { Validator, TransactionMode } from "~/utils/types";
 
 type StakingPositionFormFieldProps = {
   form: UseFormReturn<TransactionFormInput>;
@@ -17,6 +17,7 @@ type StakingPositionFormFieldProps = {
   validators: Validator[];
   setDecimals: (decimals: number) => void; // Ensure this prop is used
   onStakingPositionChange: (stakingPosition: StakingPosition) => void;
+  mode: TransactionMode;
 };
 
 export function StakingPositionFormField({
@@ -24,6 +25,7 @@ export function StakingPositionFormField({
   stakingPositions,
   validators,
   onStakingPositionChange,
+  mode,
 }: StakingPositionFormFieldProps) {
   return (
     <FormField
@@ -35,9 +37,8 @@ export function StakingPositionFormField({
             <FormLabel>Positions</FormLabel>
             <FormControl>
               <StakingPositionSelector
-                // Remove filtering for validators
+                mode={mode}
                 validators={validators}
-                // Remove filtering for staking positions
                 stakingPositions={Object.values(stakingPositions)}
                 selectedValue={
                   form.getValues().stakingPositionIndex


### PR DESCRIPTION
**Avatar shows chain logo:**
- The `AvatarImage` component now uses the `validator.chainLogo` as its source (`src={validator.chainLogo}`), displaying the chain logo directly.

**Removed small redundant avatar:**
- I removed the small avatar (`<div className="absolute ...">`) that was previously showing the chain logo or chain ID, as it would now be redundant with the chain logo in the main avatar.

**Removed the fallback showing the first letter of the validator’s name:**
- The `AvatarFallback` is no longer needed, since you’re showing the chain logo. This also removes the redundancy of displaying the first letter of the validator’s name in the avatar.

**Change display for claim rewards:**
- When claiming rewards the user is now selecting the rewards to claim instead of a staking position. As such he can easily see which positions gets him relevant rewards.


BEFORE/AFTER UNSTAKE
<img width="1502" alt="Capture d’écran 2024-09-05 à 21 08 31" src="https://github.com/user-attachments/assets/148cfd5e-cfdc-4150-bee7-e5302d63c117">


BEFORE/AFTER CLAIM
<img width="1501" alt="Capture d’écran 2024-09-05 à 21 09 21" src="https://github.com/user-attachments/assets/70e5ad2b-d29a-4dc5-a560-1578c5350fac">


