### PR TITLE
fix: handle empty transactions in cosmos history

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -273,6 +273,42 @@ function TransactionHistoryContent() {
     return () => window.removeEventListener("resize", checkMobileView);
   }, []);
 
+  useEffect(() => {
+    const fetchHistory = async () => {
+      if (!selectedAccount) return;
+
+      setIsFetchingHistory(true);
+      try {
+        const history = await getAccountHistory(
+          selectedAccount.chainId,
+          selectedAccount.address
+        );
+
+        // Add null check before setting the transaction history
+        if (history && history.transactions) {
+          // Filter out empty transactions (the ones that are {})
+          const validTransactions = history.transactions.filter(
+            (tx) => tx && Object.keys(tx).length > 0
+          );
+
+          setTransactionHistory({
+            ...history,
+            transactions: validTransactions,
+          });
+        } else {
+          setTransactionHistory(null);
+        }
+      } catch (error) {
+        console.error("Error fetching transaction history:", error);
+        setTransactionHistory(null);
+      } finally {
+        setIsFetchingHistory(false);
+      }
+    };
+
+    fetchHistory();
+  }, [selectedAccount]);
+
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6 max-h-[100vh] overflow-y-auto">
       {/* Header section */}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -150,7 +150,21 @@ function TransactionHistoryContent() {
 
     try {
       const history = await getAccountHistory(account.chainId, account.address);
-      setTransactionHistory(history);
+
+      // Add null check and filtering logic here
+      if (history && history.transactions) {
+        // Filter out empty transactions (the ones that are {})
+        const validTransactions = history.transactions.filter(
+          (tx) => tx && Object.keys(tx).length > 0
+        );
+
+        setTransactionHistory({
+          ...history,
+          transactions: validTransactions,
+        });
+      } else {
+        setTransactionHistory(null);
+      }
     } catch (error) {
       console.error("Error fetching transaction history:", error);
       setTransactionHistory(null);
@@ -272,42 +286,6 @@ function TransactionHistoryContent() {
 
     return () => window.removeEventListener("resize", checkMobileView);
   }, []);
-
-  useEffect(() => {
-    const fetchHistory = async () => {
-      if (!selectedAccount) return;
-
-      setIsFetchingHistory(true);
-      try {
-        const history = await getAccountHistory(
-          selectedAccount.chainId,
-          selectedAccount.address
-        );
-
-        // Add null check before setting the transaction history
-        if (history && history.transactions) {
-          // Filter out empty transactions (the ones that are {})
-          const validTransactions = history.transactions.filter(
-            (tx) => tx && Object.keys(tx).length > 0
-          );
-
-          setTransactionHistory({
-            ...history,
-            transactions: validTransactions,
-          });
-        } else {
-          setTransactionHistory(null);
-        }
-      } catch (error) {
-        console.error("Error fetching transaction history:", error);
-        setTransactionHistory(null);
-      } finally {
-        setIsFetchingHistory(false);
-      }
-    };
-
-    fetchHistory();
-  }, [selectedAccount]);
 
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6 max-h-[100vh] overflow-y-auto">


### PR DESCRIPTION
- Add null check before setting transaction history
- Filter out empty transaction objects from API response
- Add error handling to set transaction history to null if something goes wrong
- Prevents TypeError when trying to read properties of undefined transactions

JIRA:
