### PR TITLE
sync transaction history height with accounts list

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState, useMemo, useEffect } from "react";
+import { Suspense, useState, useMemo, useEffect, useRef } from "react";
 import { Info, Loader2, ChevronRight, ChevronLeft } from "lucide-react";
 import { Tooltip } from "~/components/ui/tooltip";
 import { useWallet } from "~/hooks/useWallet";
@@ -273,6 +273,26 @@ function TransactionHistoryContent() {
     return () => window.removeEventListener("resize", checkMobileView);
   }, []);
 
+  // Add ref for the container heights
+  const accountsListRef = useRef<HTMLDivElement>(null);
+  const [listHeight, setListHeight] = useState<number | null>(null);
+
+  // Add effect to measure and update height
+  useEffect(() => {
+    const updateHeight = () => {
+      if (accountsListRef.current) {
+        const cardContent = accountsListRef.current.querySelector(".content");
+        if (cardContent) {
+          setListHeight(cardContent.clientHeight);
+        }
+      }
+    };
+
+    updateHeight();
+    window.addEventListener("resize", updateHeight);
+    return () => window.removeEventListener("resize", updateHeight);
+  }, []);
+
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6 max-h-[100vh] overflow-y-auto">
       {/* Header section */}
@@ -312,11 +332,11 @@ function TransactionHistoryContent() {
       <div className="flex flex-col lg:flex-row gap-4">
         {/* Show accounts list if: desktop OR (mobile AND no selection) */}
         {(!isMobileView || (isMobileView && !selectedAccount)) && (
-          <Card className="w-full lg:w-1/2">
+          <Card className="w-full lg:w-1/2" ref={accountsListRef}>
             <CardHeader>
               <CardTitle>Available Accounts</CardTitle>
             </CardHeader>
-            <CardContent>
+            <CardContent className="content">
               {isLoading ? (
                 <Loader2 className="animate-spin" />
               ) : filteredAccounts.length > 0 ? (
@@ -430,7 +450,16 @@ function TransactionHistoryContent() {
                 isFetchingHistory ? (
                   <Loader2 className="animate-spin" />
                 ) : transactionHistory ? (
-                  <div className="space-y-4 max-h-[400px] lg:max-h-[600px] overflow-y-auto px-1">
+                  <div
+                    className="space-y-4 overflow-y-auto px-1"
+                    style={{
+                      maxHeight: isMobileView
+                        ? "400px"
+                        : listHeight
+                        ? `${listHeight}px`
+                        : "600px",
+                    }}
+                  >
                     {transactionHistory.transactions.map(
                       (tx: ParsedTransaction) => (
                         <div key={tx.parsed.id}>

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -277,7 +277,6 @@ function TransactionHistoryContent() {
   const accountsListRef = useRef<HTMLDivElement>(null);
   const [listHeight, setListHeight] = useState<number | null>(null);
 
-  // Add effect to measure and update height
   useEffect(() => {
     const updateHeight = () => {
       if (accountsListRef.current) {


### PR DESCRIPTION
Original issue: the transaction history list had a fixed height.
Improvement: the transaction history list height is now identical to the left section of the page (if list of operation is bigger, a scroll bar will be added)
//No impact on mobile display

- Add dynamic height calculation for transaction history panel
- Match transaction list height with accounts list in desktop view
- Maintain fixed height (400px) for mobile view
- Add resize listener to update heights on window changes
